### PR TITLE
Fix glibc version on deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM golang:1.20 AS builder
+FROM golang:1.20-bookworm AS builder
 WORKDIR /go/app
 COPY . .
 RUN go build -buildvcs=false
 
 FROM redis/redis-stack-server:7.0.6-RC8 AS redis-stack
 
-FROM redis:7-bullseye
+FROM redis:7-bookworm
 RUN ln -sf /bin/bash /bin/sh
 RUN apt-get update && apt-get install -y ca-certificates procps && apt-get clean
 COPY --from=redis-stack /opt/redis-stack/lib/redisearch.so /opt/redis-stack/lib/redisearch.so


### PR DESCRIPTION
The previous commit triggered a failed deployment.

```
[info] classes.wtf: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by classes.wtf)
[info] classes.wtf: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by classes.wtf)
```

This is because the Dockerfile was written poorly, and Debian 12 "bookworm" came out on June 10, a couple weeks ago. The `redis:7-bullseye` image is on Debian 11 bullseye, with glibc 2.31, whereas the `golang:1.20` image was overwritten to the newest `golang:1.20-bookworm, so the binary was compiled with dynamic links to glibc 2.32 and 2.34.

The fix is just to pin them both to bookworm.