### PR TITLE
Adding GENED + Divisional Labels from Curricle

### DIFF
--- a/datasource/course.go
+++ b/datasource/course.go
@@ -50,11 +50,11 @@ type Course struct {
 	// MeetingPatterns describes the course's meeting times.
 	MeetingPatterns []MeetingPattern `json:"meetingPatterns"`
 
-	// GenEdArea contains the GENED requirement(s), if any. Empty if not a GENED. 
-	GenEdArea[]string `json:"genEdArea"`
+	// GenEdArea contains the GENED requirement(s), if any. Empty if not a GENED.
+	GenEdArea []string `json:"genEdArea"`
 
-	// DivisionalDist contains the divisional distribution requirement(s), if any. 
-	DivisionalDist[]string `json:"divisionalDist"`
+	// DivisionalDist contains the divisional distribution requirement(s), if any.
+	DivisionalDist []string `json:"divisionalDist"`
 }
 
 // Instructor describes a faculty course instructor.

--- a/datasource/course.go
+++ b/datasource/course.go
@@ -49,6 +49,9 @@ type Course struct {
 
 	// MeetingPatterns describes the course's meeting times.
 	MeetingPatterns []MeetingPattern `json:"meetingPatterns"`
+
+	// GenEdArea contains the GENED requirement(s), if any. Empty if not a GENED. 
+	GenEdArea[]string `json:"genEdArea"`
 }
 
 // Instructor describes a faculty course instructor.

--- a/datasource/course.go
+++ b/datasource/course.go
@@ -52,6 +52,9 @@ type Course struct {
 
 	// GenEdArea contains the GENED requirement(s), if any. Empty if not a GENED. 
 	GenEdArea[]string `json:"genEdArea"`
+
+	// DivisionalDist contains the divisional distribution requirement(s), if any. 
+	DivisionalDist[]string `json:"divisionalDist"`
 }
 
 // Instructor describes a faculty course instructor.

--- a/datasource/curricle.go
+++ b/datasource/curricle.go
@@ -81,8 +81,8 @@ func (s *SearchCurricle) Fetch(page uint) (courses []Course, err error) {
 			Description:        sanitizeHtml(node["courseDescriptionLong"].(string)),
 			Instructors:        instructors,
 			MeetingPatterns:    meetingPatterns,
-			GenEdArea:          getGenEdInfo(node["courseAttributes"].([]interface{})), 
-			DivisionalDist:	 	getDivisionalInfo(node["courseAttributes"].([]interface{})),
+			GenEdArea:          getGenEdInfo(node["courseAttributes"].([]interface{})),
+			DivisionalDist:     getDivisionalInfo(node["courseAttributes"].([]interface{})),
 		})
 	}
 

--- a/datasource/curricle.go
+++ b/datasource/curricle.go
@@ -81,8 +81,8 @@ func (s *SearchCurricle) Fetch(page uint) (courses []Course, err error) {
 			Description:        sanitizeHtml(node["courseDescriptionLong"].(string)),
 			Instructors:        instructors,
 			MeetingPatterns:    meetingPatterns,
-			GenEdArea:          getGenEdInfo(node["courseAttributes"].([]interface{})),
-			DivisionalDist:     getDivisionalInfo(node["courseAttributes"].([]interface{})),
+			GenEdArea:          getGenEdInfo(node["courseAttributes"].([]any)),
+			DivisionalDist:     getDivisionalInfo(node["courseAttributes"].([]any)),
 		})
 	}
 

--- a/datasource/curricle.go
+++ b/datasource/curricle.go
@@ -82,6 +82,7 @@ func (s *SearchCurricle) Fetch(page uint) (courses []Course, err error) {
 			Instructors:        instructors,
 			MeetingPatterns:    meetingPatterns,
 			GenEdArea:          getGenEdInfo(node["courseAttributes"].([]interface{})), 
+			DivisionalDist:	 	getDivisionalInfo(node["courseAttributes"].([]interface{})),
 		})
 	}
 

--- a/datasource/curricle.go
+++ b/datasource/curricle.go
@@ -81,6 +81,7 @@ func (s *SearchCurricle) Fetch(page uint) (courses []Course, err error) {
 			Description:        sanitizeHtml(node["courseDescriptionLong"].(string)),
 			Instructors:        instructors,
 			MeetingPatterns:    meetingPatterns,
+			GenEdArea:          getGenEdInfo(node["courseAttributes"].([]interface{})), 
 		})
 	}
 

--- a/datasource/curricle.gql
+++ b/datasource/curricle.gql
@@ -31,6 +31,12 @@ query getCourses(
       componentFiltered
       courseDescription
       courseDescriptionLong
+      courseAttributes {
+        crseAttribute
+        crseAttributeDescription
+        crseAttrValue
+        crseAttrValueDescription
+      }
       courseInstructors {
         id
         displayName

--- a/datasource/utils.go
+++ b/datasource/utils.go
@@ -34,7 +34,7 @@ func getDivisionalInfo(intAttributes []interface{}) []string {
 	// Type conversion, since we're dealing with an interface.
 	areas := []string{}
 	for _, item := range intAttributes {
-		attrMap, _ := item.(map[string]any)
+		attrMap := item.(map[string]any)
 		divAttr, ok := attrMap["crseAttrValue"].(string)
 		if !ok {
 			continue

--- a/datasource/utils.go
+++ b/datasource/utils.go
@@ -4,6 +4,29 @@ package datasource
 
 import "strconv"
 
+var DivisionalAreas = [3]string{"Arts and Humanities", "Social Sciences", "Science & Engineering & Applied Science"}
+
+func getGenEdInfo(intAttributes []interface{}) []string {
+
+	// Type conversion, since we're dealing with an interface.
+	var attributes []map[string]interface {}
+	for _, item := range intAttributes {
+		attrMap, ok := item.(map[string]interface {}) 
+		if !ok {
+			panic("An item in courseAttributes is not of type map[string]interface")
+		}
+		attributes = append(attributes, attrMap)
+	}
+
+	areas := []string{}
+	for _, attribute := range attributes {
+		if attribute["crseAttributeDescription"] == "FAS General Education" {
+			areas = append(areas, attribute["crseAttrValueDescription"].(string))
+		}
+	}
+	return areas // if empty, not a GENED. 
+}
+
 func castAsInt(value string) uint32 {
 	x, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {

--- a/datasource/utils.go
+++ b/datasource/utils.go
@@ -29,7 +29,7 @@ func checkDivisionalArea(val string) bool {
 	return false
 }
 
-func getDivisionalInfo(intAttributes []interface{}) []string {
+func getDivisionalInfo(intAttributes []any) []string {
 
 	// Type conversion, since we're dealing with an interface.
 	areas := []string{}

--- a/datasource/utils.go
+++ b/datasource/utils.go
@@ -27,6 +27,38 @@ func getGenEdInfo(intAttributes []interface{}) []string {
 	return areas // if empty, not a GENED. 
 }
 
+func checkDivisionalArea(val string) bool {
+	for _, area := range DivisionalAreas {
+		if val == area {
+			return true
+		}
+	}
+	return false
+}
+
+func getDivisionalInfo(intAttributes []interface{}) []string {
+
+	// Type conversion, since we're dealing with an interface.
+	var attributes []map[string]interface {}
+	for _, item := range intAttributes {
+		attrMap, ok := item.(map[string]interface {})
+		if !ok {
+			panic("An item in courseAttributes is not of type map[string]interface")
+		}
+		attributes = append(attributes, attrMap)
+	}
+
+	areas := []string{}
+	for _, attribute := range attributes {
+		divAttr, ok := attribute["crseAttrValueDescription"].(string)
+		if !ok {  continue  } // sometimes the value is nil. Just move to the next one.
+		if attribute["crseAttributeDescription"] == "FAS Divisional Distribution" && checkDivisionalArea(divAttr) {
+			areas = append(areas, divAttr)
+		}
+	}
+	return areas // if empty, no divisional distributions. 
+}
+
 func castAsInt(value string) uint32 {
 	x, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {

--- a/datasource/utils.go
+++ b/datasource/utils.go
@@ -4,31 +4,24 @@ package datasource
 
 import "strconv"
 
-var DivisionalAreas = [3]string{"Arts and Humanities", "Social Sciences", "Science & Engineering & Applied Science"}
+// Any crseAttrValue's that don't fall into these are labeled "None"
+var divisionalAreas = [3]string{"A&H", "SCI", "SOC"}
 
-func getGenEdInfo(intAttributes []interface{}) []string {
+func getGenEdInfo(intAttributes []any) []string {
 
-	// Type conversion, since we're dealing with an interface.
-	var attributes []map[string]interface {}
-	for _, item := range intAttributes {
-		attrMap, ok := item.(map[string]interface {}) 
-		if !ok {
-			panic("An item in courseAttributes is not of type map[string]interface")
-		}
-		attributes = append(attributes, attrMap)
-	}
-
+	// Get the gen-ed areas from the course attributes.
 	areas := []string{}
-	for _, attribute := range attributes {
-		if attribute["crseAttributeDescription"] == "FAS General Education" {
-			areas = append(areas, attribute["crseAttrValueDescription"].(string))
+	for _, item := range intAttributes {
+		attrMap := item.(map[string]any)
+		if attrMap["crseAttribute"] == "LGE" {
+			areas = append(areas, attrMap["crseAttrValue"].(string))
 		}
 	}
-	return areas // if empty, not a GENED. 
+	return areas // if empty, not a GENED.
 }
 
 func checkDivisionalArea(val string) bool {
-	for _, area := range DivisionalAreas {
+	for _, area := range divisionalAreas {
 		if val == area {
 			return true
 		}
@@ -39,24 +32,19 @@ func checkDivisionalArea(val string) bool {
 func getDivisionalInfo(intAttributes []interface{}) []string {
 
 	// Type conversion, since we're dealing with an interface.
-	var attributes []map[string]interface {}
-	for _, item := range intAttributes {
-		attrMap, ok := item.(map[string]interface {})
-		if !ok {
-			panic("An item in courseAttributes is not of type map[string]interface")
-		}
-		attributes = append(attributes, attrMap)
-	}
-
 	areas := []string{}
-	for _, attribute := range attributes {
-		divAttr, ok := attribute["crseAttrValueDescription"].(string)
-		if !ok {  continue  } // sometimes the value is nil. Just move to the next one.
-		if attribute["crseAttributeDescription"] == "FAS Divisional Distribution" && checkDivisionalArea(divAttr) {
+	for _, item := range intAttributes {
+		attrMap, _ := item.(map[string]any)
+		divAttr, ok := attrMap["crseAttrValue"].(string)
+		if !ok {
+			continue
+		} // sometimes the value is nil. Just move to the next one.
+
+		if attrMap["crseAttribute"] == "LDD" && checkDivisionalArea(divAttr) {
 			areas = append(areas, divAttr)
 		}
 	}
-	return areas // if empty, no divisional distributions. 
+	return areas // if empty, no divisional distributions.
 }
 
 func castAsInt(value string) uint32 {


### PR DESCRIPTION
These changes query GENED and Divisional Distribution information from Curricle and add them to the relevant `courses-xxx.json` file as an array of tags. If that array is empty, that indicates that the course has no relevant GENED or Divisional tags. 

I've only used Go a handful of times before, so suggestions/clean-up on style are welcome. In particular, there was a messy type conversion from `raw query -> interface intermediate -> strings` (see `utils.go`). 

