### PR TITLE
Deploy on manual workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/main'
     needs: [go, web]
     concurrency:
       group: deploy


### PR DESCRIPTION
Fulfills the purpose of 5276fe051b08f9520bf2d06314d82cced8989fc3 by running the `deploy` job on the `workflow_dispatch` event.