### PR TITLE
Search AY 2024 data

### DIFF
--- a/datasource/myharvard.go
+++ b/datasource/myharvard.go
@@ -116,8 +116,8 @@ func (s *SearchMh) Fetch(page uint) (courses []Course, err error) {
 func (s *SearchMh) request(page uint) (props map[string]any, results map[string]any, err error) {
 	var yearFilter string
 
-	if s.Year == 2023 {
-		yearFilter = `(STRM:"2228" | STRM:"2232")`
+	if s.Year == 2024 {
+		yearFilter = `(STRM:"2238" | STRM:"2242")`
 	} else {
 		err = fmt.Errorf("no filter set for year %v", s.Year)
 		return

--- a/datasource/myharvard.go
+++ b/datasource/myharvard.go
@@ -114,12 +114,8 @@ func (s *SearchMh) Fetch(page uint) (courses []Course, err error) {
 }
 
 func (s *SearchMh) request(page uint) (props map[string]any, results map[string]any, err error) {
-	var yearFilter string
-
-	if s.Year == 2024 {
-		yearFilter = `(STRM:"2238" | STRM:"2242")`
-	} else {
-		err = fmt.Errorf("no filter set for year %v", s.Year)
+	yearFilter, err := mhGetYearFilter(s.Year)
+	if err != nil {
 		return
 	}
 
@@ -160,6 +156,20 @@ func (s *SearchMh) request(page uint) (props map[string]any, results map[string]
 		err = fmt.Errorf("passed page size of %v, but received page size of %v",
 			mhPageSize, realPageSize)
 		return
+	}
+	return
+}
+
+// Convert an academic year to a query selecting that year's terms.
+// Example: 2024 selects Fall 2023 and Spring 2024.
+func mhGetYearFilter(year int) (yearFilter string, err error) {
+	switch year {
+	case 2024:
+		yearFilter = `(STRM:"2238" | STRM:"2242")`
+	case 2023:
+		yearFilter = `(STRM:"2228" | STRM:"2232")`
+	default:
+		err = fmt.Errorf("no filter set for year %v", year)
 	}
 	return
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -27,7 +27,7 @@
   let landing = query === "";
   $: if (query) landing = false;
 
-  let ay2024 = false;
+  let ay2024 = true;
 
   const { data, error, search } = createSearcher();
   $: finalQuery =

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -111,7 +111,7 @@
     {#if !landing}
       <label class="flex text-sm mb-2">
         <input class="mr-2" type="checkbox" bind:checked={ay2024} />
-        Only show AY 2023-2024 courses
+        Only show AY 2023–2024 courses
       </label>
     {/if}
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -27,11 +27,11 @@
   let landing = query === "";
   $: if (query) landing = false;
 
-  let ay2023 = false;
+  let ay2024 = false;
 
   const { data, error, search } = createSearcher();
   $: finalQuery =
-    (ay2023 ? "@academicYear:[2023 2023] " : "") + normalizeText(query);
+    (ay2024 ? "@academicYear:[2024 2024] " : "") + normalizeText(query);
   $: search(finalQuery);
 
   // Render courses incrementally in batches of 20 at a time, to avoid slowing
@@ -110,8 +110,8 @@
 
     {#if !landing}
       <label class="flex text-sm mb-2">
-        <input class="mr-2" type="checkbox" bind:checked={ay2023} />
-        Only show AY 2022-2023 courses
+        <input class="mr-2" type="checkbox" bind:checked={ay2024} />
+        Only show AY 2023-2024 courses
       </label>
     {/if}
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 
 		default:
 			log.Printf("downloading from My.Harvard for year %d", *year)
-			log.Print("note: course data may be missing for years except the older current one")
+			log.Print("note: course data may be missing for years except the current one")
 			mh := datasource.SearchMh{Year: *year}
 			courses = append(courses, datasource.PaginatedDownload(&mh, 32)...)
 		}


### PR DESCRIPTION
Updates the website and data sources for the new academic year! 🎉 

However, we should avoid merging this until we've verified that the deployment has loaded the updated `courses.json` from S3. Otherwise, with the AY 2024 checkbox now checked by default, users will see 0 results. :(
- [x] Tested locally
- [x] Deployment ready